### PR TITLE
Fix rultor release - deploy npm-hosted-adapter subproject

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -28,7 +28,7 @@ release:
     gpg --allow-secret-key-import --no-tty --batch --import /home/r/secring.gpg
     mvn versions:set "-DnewVersion=${tag}" --settings ../settings.xml
     git commit -am "${tag}"
-    mvn clean deploy -Partipie,publish,sonatype,qulice,gpg-sign --errors --settings ../settings.xml
+    mvn -f npm-hosted-adapter clean deploy -Partipie,publish,sonatype,qulice,gpg-sign --errors --settings ../settings.xml
 architect:
   - g4s8
   - yegor256


### PR DESCRIPTION
Calling deploy for the `npm-hosted-adapter` subproject.
 
Closes #90