### PR TITLE
#124 - Removed codecov upload phase from maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,10 +27,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-jdk-${{ matrix.java }}-maven-
       - name: Build it with Maven
-        run: mvn -B verify -Pqulice -Pjacoco
-      - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.java == 11
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./target/site/jacoco-aggregate/jacoco.xml
-          fail_ci_if_error: true
+        run: mvn -B verify -Pqulice


### PR DESCRIPTION
Closes #124
Removed codecov upload phase from maven.yml, so it won't block CI check