### PR TITLE
#119 - Fix `time` field in meta.json

### DIFF
--- a/src/main/java/com/artipie/npm/Meta.java
+++ b/src/main/java/com/artipie/npm/Meta.java
@@ -26,6 +26,10 @@ package com.artipie.npm;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Set;
 import javax.json.Json;
@@ -87,6 +91,10 @@ final class Meta {
                 )
             );
         }
+        for (final String version : keys) {
+            patch.add(String.format("/time/%s", version), Meta.now());
+        }
+        patch.replace("/time/modified", Meta.now());
         return new Meta(
             patch
                 .build()
@@ -104,5 +112,19 @@ final class Meta {
                 this.json.toString().getBytes(StandardCharsets.UTF_8)
             )
         );
+    }
+
+    /**
+     * Current time.
+     * @return Current time.
+     */
+    private static String now() {
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME
+            .format(
+                ZonedDateTime.ofInstant(
+                    Instant.now(),
+                    ZoneOffset.UTC
+                )
+            );
     }
 }

--- a/src/main/java/com/artipie/npm/Meta.java
+++ b/src/main/java/com/artipie/npm/Meta.java
@@ -23,13 +23,10 @@
  */
 package com.artipie.npm;
 
+import com.artipie.npm.misc.DateTimeNowStr;
 import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Set;
 import javax.json.Json;
@@ -91,10 +88,11 @@ final class Meta {
                 )
             );
         }
+        final String now = new DateTimeNowStr().value();
         for (final String version : keys) {
-            patch.add(String.format("/time/%s", version), Meta.now());
+            patch.add(String.format("/time/%s", version), now);
         }
-        patch.replace("/time/modified", Meta.now());
+        patch.replace("/time/modified", now);
         return new Meta(
             patch
                 .build()
@@ -112,19 +110,5 @@ final class Meta {
                 this.json.toString().getBytes(StandardCharsets.UTF_8)
             )
         );
-    }
-
-    /**
-     * Current time.
-     * @return Current time.
-     */
-    private static String now() {
-        return DateTimeFormatter.ISO_LOCAL_DATE_TIME
-            .format(
-                ZonedDateTime.ofInstant(
-                    Instant.now(),
-                    ZoneOffset.UTC
-                )
-            );
     }
 }

--- a/src/main/java/com/artipie/npm/NpmPublishJsonToMetaSkelethon.java
+++ b/src/main/java/com/artipie/npm/NpmPublishJsonToMetaSkelethon.java
@@ -23,10 +23,7 @@
  */
 package com.artipie.npm;
 
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import com.artipie.npm.misc.DateTimeNowStr;
 import javax.json.Json;
 import javax.json.JsonObject;
 
@@ -71,6 +68,7 @@ final class NpmPublishJsonToMetaSkelethon {
      * @return The skeleton for meta.json file
      */
     public JsonObject skeleton() {
+        final String now = new DateTimeNowStr().value();
         return Json.createObjectBuilder()
             .add(
                 NpmPublishJsonToMetaSkelethon.NAME,
@@ -87,26 +85,12 @@ final class NpmPublishJsonToMetaSkelethon {
             .add(
                 "time",
                 Json.createObjectBuilder()
-                    .add("created", NpmPublishJsonToMetaSkelethon.now())
-                    .add("modified", NpmPublishJsonToMetaSkelethon.now())
+                    .add("created", now)
+                    .add("modified", now)
                     .build()
             )
             .add("users", Json.createObjectBuilder().build())
             .add("versions", Json.createObjectBuilder().build())
             .build();
-    }
-
-    /**
-     * Current time.
-     * @return Current time.
-     */
-    private static String now() {
-        return DateTimeFormatter.ISO_LOCAL_DATE_TIME
-            .format(
-                ZonedDateTime.ofInstant(
-                    Instant.now(),
-                    ZoneOffset.UTC
-                )
-            );
     }
 }

--- a/src/main/java/com/artipie/npm/NpmPublishJsonToMetaSkelethon.java
+++ b/src/main/java/com/artipie/npm/NpmPublishJsonToMetaSkelethon.java
@@ -87,16 +87,8 @@ final class NpmPublishJsonToMetaSkelethon {
             .add(
                 "time",
                 Json.createObjectBuilder()
-                    .add(
-                        "created",
-                        DateTimeFormatter.ISO_LOCAL_DATE_TIME
-                            .format(
-                                ZonedDateTime.ofInstant(
-                                    Instant.now(),
-                                    ZoneOffset.UTC
-                                )
-                            )
-                    )
+                    .add("created", NpmPublishJsonToMetaSkelethon.now())
+                    .add("modified", NpmPublishJsonToMetaSkelethon.now())
                     .build()
             )
             .add("users", Json.createObjectBuilder().build())
@@ -104,4 +96,17 @@ final class NpmPublishJsonToMetaSkelethon {
             .build();
     }
 
+    /**
+     * Current time.
+     * @return Current time.
+     */
+    private static String now() {
+        return DateTimeFormatter.ISO_LOCAL_DATE_TIME
+            .format(
+                ZonedDateTime.ofInstant(
+                    Instant.now(),
+                    ZoneOffset.UTC
+                )
+            );
+    }
 }

--- a/src/main/java/com/artipie/npm/misc/DateTimeNowStr.java
+++ b/src/main/java/com/artipie/npm/misc/DateTimeNowStr.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 artipie.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.npm.misc;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Provides current date and time.
+ * @since 0.7.6
+ */
+public final class DateTimeNowStr {
+
+    /**
+     * Current time.
+     */
+    private final String currtime;
+
+    /**
+     * Ctor.
+     */
+    public DateTimeNowStr() {
+        this.currtime = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+            .format(
+                ZonedDateTime.ofInstant(
+                    Instant.now(),
+                    ZoneOffset.UTC
+                )
+            );
+    }
+
+    /**
+     * Current date and time.
+     * @return Current date and time.
+     */
+    public String value() {
+        return this.currtime;
+    }
+}


### PR DESCRIPTION
Closes #119 
Add time for uploaded version and update `modified` time in `Meta#updateMeta`. Disable test. Also modified `time` field in existing test as it always is contained in `meta.json` because `NpmPublishJsonToMetaSkelethon#skeleton` add them.