### PR TITLE
#89 - Use PublisherAs instead of Concatenation

### DIFF
--- a/src/test/java/com/artipie/npm/proxy/RxNpmProxyStorageTest.java
+++ b/src/test/java/com/artipie/npm/proxy/RxNpmProxyStorageTest.java
@@ -23,10 +23,10 @@
  */
 package com.artipie.npm.proxy;
 
-import com.artipie.asto.Concatenation;
 import com.artipie.asto.Content;
 import com.artipie.asto.Key;
 import com.artipie.asto.Storage;
+import com.artipie.asto.ext.PublisherAs;
 import com.artipie.asto.memory.InMemoryStorage;
 import com.artipie.asto.rx.RxStorageWrapper;
 import com.artipie.npm.proxy.model.NpmAsset;
@@ -38,12 +38,10 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.concurrent.ExecutionException;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -92,24 +90,13 @@ public final class RxNpmProxyStorageTest {
     private Storage delegate;
 
     @Test
-    @Disabled
-    public void savesPackage() throws IOException, ExecutionException, InterruptedException {
+    public void savesPackage() throws IOException {
         this.doSavePackage("asdas", RxNpmProxyStorageTest.REFRESHED);
         MatcherAssert.assertThat(
-            new String(
-                new Concatenation(
-                    this.delegate.value(new Key.From("asdas/meta.json")).get()
-                ).single().blockingGet().array(),
-                StandardCharsets.UTF_8
-            ),
+            this.publisherAsStr("asdas/meta.json"),
             new IsEqual<>(RxNpmProxyStorageTest.readContent())
         );
-        final String metadata = new String(
-            new Concatenation(
-                this.delegate.value(new Key.From("asdas/meta.meta")).get()
-            ).single().blockingGet().array(),
-            StandardCharsets.UTF_8
-        );
+        final String metadata = this.publisherAsStr("asdas/meta.meta");
         final JsonObject json = new JsonObject(metadata);
         MatcherAssert.assertThat(
             json.getString("last-modified"),
@@ -122,82 +109,79 @@ public final class RxNpmProxyStorageTest {
     }
 
     @Test
-    @Disabled
-    public void savesAsset() throws ExecutionException, InterruptedException {
+    public void savesAsset() {
         final String path = "asdas/-/asdas-1.0.0.tgz";
         this.doSaveAsset(path);
         MatcherAssert.assertThat(
-            new String(
-                new Concatenation(
-                    this.delegate.value(new Key.From(path)).get()
-                ).single().blockingGet().array(),
-                StandardCharsets.UTF_8
-            ),
+            "Content of asset is correct",
+            this.publisherAsStr(path),
             new IsEqual<>(RxNpmProxyStorageTest.DEF_CONTENT)
         );
-        final String metadata = new String(
-            new Concatenation(
-                this.delegate.value(new Key.From("asdas/-/asdas-1.0.0.tgz.meta")).get()
-            ).single().blockingGet().array(),
-            StandardCharsets.UTF_8
-        );
+        final String metadata = this.publisherAsStr("asdas/-/asdas-1.0.0.tgz.meta");
         final JsonObject json = new JsonObject(metadata);
         MatcherAssert.assertThat(
+            "Last-modified is correct",
             json.getString("last-modified"),
             new IsEqual<>(RxNpmProxyStorageTest.MODIFIED)
         );
         MatcherAssert.assertThat(
+            "Content-type of asset is correct",
             json.getString("content-type"),
             new IsEqual<>(RxNpmProxyStorageTest.CONTENT_TYPE)
         );
     }
 
     @Test
-    @Disabled
     public void loadsPackage() throws IOException {
         final String name = "asdas";
         this.doSavePackage(name, RxNpmProxyStorageTest.REFRESHED);
         final NpmPackage pkg = this.storage.getPackage(name).blockingGet();
         MatcherAssert.assertThat(
+            "Package name is correct",
             pkg.name(),
             new IsEqual<>(name)
         );
         MatcherAssert.assertThat(
+            "Content of package is correct",
             pkg.content(),
             new IsEqual<>(RxNpmProxyStorageTest.readContent())
         );
         MatcherAssert.assertThat(
+            "Modified date is correct",
             pkg.meta().lastModified(),
             new IsEqual<>(RxNpmProxyStorageTest.MODIFIED)
         );
         MatcherAssert.assertThat(
+            "Refreshed date is correct",
             pkg.meta().lastRefreshed(),
             new IsEqual<>(RxNpmProxyStorageTest.REFRESHED)
         );
     }
 
     @Test
-    @Disabled
     public void loadsAsset() {
         final String path = "asdas/-/asdas-1.0.0.tgz";
         this.doSaveAsset(path);
         final NpmAsset asset = this.storage.getAsset(path).blockingGet();
         MatcherAssert.assertThat(
+            "Path to asset is correct",
             asset.path(),
             new IsEqual<>(path)
         );
         MatcherAssert.assertThat(
-            new String(
-                new Concatenation(asset.dataPublisher()).single().blockingGet().array(),
-                StandardCharsets.UTF_8
-            ),
+            "Content of asset is correct",
+            new PublisherAs(asset.dataPublisher())
+                .asciiString()
+                .toCompletableFuture().join(),
             new IsEqual<>(RxNpmProxyStorageTest.DEF_CONTENT)
         );
         MatcherAssert.assertThat(
+            "Modified date is correct",
             asset.meta().lastModified(),
             new IsEqual<>(RxNpmProxyStorageTest.MODIFIED)
         );
         MatcherAssert.assertThat(
+            "Content-type of asset is correct",
             asset.meta().contentType(),
             new IsEqual<>(RxNpmProxyStorageTest.CONTENT_TYPE)
         );
@@ -223,6 +207,13 @@ public final class RxNpmProxyStorageTest {
     void setUp() {
         this.delegate = new InMemoryStorage();
         this.storage = new RxNpmProxyStorage(new RxStorageWrapper(this.delegate));
+    }
+
+    private String publisherAsStr(final String path) {
+        return new PublisherAs(
+            this.delegate.value(new Key.From(path)).join()
+        ).asciiString()
+        .toCompletableFuture().join();
     }
 
     private void doSavePackage(final String name, final OffsetDateTime refreshed)


### PR DESCRIPTION
Part of #89 
It returns "foobar" but with `NULL` values at the end in buffer
```
final String res = new String(
    new Concatenation(asset.dataPublisher()).single().blockingGet().a.array(),
    StandardCharsets.UTF_8
)
```
Using `PublisherAs` solved this problem.