### PR TITLE
#89 - Fix NpmProxyITCase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>vertx-server</artifactId>
-      <version>0.3</version>
+      <version>0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/artipie/npm/proxy/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/proxy/NpmProxyITCase.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -92,7 +91,6 @@ public final class NpmProxyITCase {
     private VertxSliceServer srv;
 
     @Test
-    @Disabled
     public void installModule() throws IOException, InterruptedException {
         final Container.ExecResult result = this.npmcnter.execInContainer(
             "npm",


### PR DESCRIPTION
Closes #89 
This test didn't work because `reason: Parse Error: Content-Length can't be present with Transfer-Encoding`.
Updating `vertx-server` version from `0.3` to `0.4` solved this problem.