### PR TITLE
#137 - Integration tests enabled, NpmCommandsTest renamed to NpmIT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,34 +216,22 @@ SOFTWARE.
         <filtering>false</filtering>
       </testResource>
     </testResources>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>com.qulice</groupId>
-          <artifactId>qulice-maven-plugin</artifactId>
-          <configuration>
-            <excludes combine.children="append">
-              <exclude>checkstyle:.*/src/test/resources/.*</exclude>
-              <exclude>pmd:.*/src/test/resources/.*</exclude>
-            </excludes>
-            <license>file:${basedir}/LICENSE.txt</license>
-          </configuration>
-        </plugin>
-        <plugin>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <configuration>
-            <parallel>none</parallel>
-          </configuration>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+          <trimStackTrace>false</trimStackTrace>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/src/test/java/com/artipie/npm/NpmIT.java
+++ b/src/test/java/com/artipie/npm/NpmIT.java
@@ -58,7 +58,7 @@ import org.testcontainers.containers.GenericContainer;
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @DisabledOnOs(OS.WINDOWS)
-public final class NpmCommandsTest {
+public final class NpmIT {
 
     /**
      * Temporary directory for all tests.


### PR DESCRIPTION
Closes #137 
Integration tests enabled, `NpmCommandsTest` renamed to `NpmIT`