### PR TITLE
#144 - Change docker image

### DIFF
--- a/src/test/java/com/artipie/npm/proxy/NpmProxyITCase.java
+++ b/src/test/java/com/artipie/npm/proxy/NpmProxyITCase.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.Container;
@@ -55,15 +54,9 @@ import org.testcontainers.containers.GenericContainer;
  *
  * @since 0.1
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
- * @todo #141:30min Fix NPM proxy integration tests.
- *  NPM proxy tests became broken by release on newer client ver 0.7.3
- *  It seems that container used in tests needs to be updated
- *  or replaced with other image with NPM client.
- *  The tests need to be fixed an re-enabled.
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")
 @org.testcontainers.junit.jupiter.Testcontainers
-@Disabled
 public final class NpmProxyITCase {
     /**x
      * Vertx instance.
@@ -216,7 +209,7 @@ public final class NpmProxyITCase {
      */
     private static class NodeContainer extends GenericContainer<NodeContainer> {
         NodeContainer() {
-            super("node:latest");
+            super("node:14-alpine");
         }
     }
 


### PR DESCRIPTION
Closes #144 
Fix `NpmProxyITCase` by changing docker image from `node:latest` to `node:14-alpine`