### PR TITLE
#119 - Fix backward compatibility

### DIFF
--- a/src/main/java/com/artipie/npm/Meta.java
+++ b/src/main/java/com/artipie/npm/Meta.java
@@ -92,7 +92,7 @@ final class Meta {
         for (final String version : keys) {
             patch.add(String.format("/time/%s", version), now);
         }
-        patch.replace("/time/modified", now);
+        patch.add("/time/modified", now);
         return new Meta(
             patch
                 .build()


### PR DESCRIPTION
Part of #119 
Fix backward compatibility with metadata of earlier versions. Bug report: https://github.com/artipie/npm-adapter/issues/139#issuecomment-751223870