### PR TITLE
#139 - Fix regex bug in curlWithScope

### DIFF
--- a/src/main/java/com/artipie/npm/TgzRelativePath.java
+++ b/src/main/java/com/artipie/npm/TgzRelativePath.java
@@ -60,10 +60,10 @@ public class TgzRelativePath {
         final String result;
         if (npms.isPresent()) {
             result = npms.get();
-        } else if (npmws.isPresent()) {
-            result = npmws.get();
         } else if (curls.isPresent()) {
             result = curls.get();
+        } else if (npmws.isPresent()) {
+            result = npmws.get();
         } else if (curlws.isPresent()) {
             result = curlws.get();
         } else {
@@ -96,7 +96,7 @@ public class TgzRelativePath {
      * @return The npm scoped path if found.
      */
     private Optional<String> curlWithScope() {
-        return this.firstGroup(Pattern.compile("(@[\\w-]+/[\\w.-]+/[\\w.-]+.tgz)"));
+        return this.firstGroup(Pattern.compile("(@[\\w-]+/[\\w.-]+/[\\w.-]+[/]?[\\w.-]+.tgz)"));
     }
 
     /**

--- a/src/main/java/com/artipie/npm/TgzRelativePath.java
+++ b/src/main/java/com/artipie/npm/TgzRelativePath.java
@@ -78,7 +78,7 @@ public class TgzRelativePath {
      * @return The npm scoped path if found.
      */
     private Optional<String> npmWithScope() {
-        return this.firstGroup(Pattern.compile("(@[\\w-]+/[\\w.-]+/-/@[\\w-]+/[\\w.-]+.tgz)"));
+        return this.firstGroup(Pattern.compile("(@[\\w-]+/[\\w.-]+/-/@[\\w-]+/[\\w.-]+.tgz$)"));
     }
 
     /**
@@ -87,7 +87,7 @@ public class TgzRelativePath {
      * @return The npm scoped path if found.
      */
     private Optional<String> npmWithoutScope() {
-        return this.firstGroup(Pattern.compile("([\\w.-]+/-/[\\w.-]+.tgz)"));
+        return this.firstGroup(Pattern.compile("([\\w.-]+/-/[\\w.-]+.tgz$)"));
     }
 
     /**
@@ -96,7 +96,9 @@ public class TgzRelativePath {
      * @return The npm scoped path if found.
      */
     private Optional<String> curlWithScope() {
-        return this.firstGroup(Pattern.compile("(@[\\w-]+/[\\w.-]+/[\\w.-]+[/]?[\\w.-]+.tgz)"));
+        return this.firstGroup(
+            Pattern.compile("(@[\\w-]+/[\\w.-]+/(@?(?<!-/@)[\\w.-]+/)*[\\w.-]+.tgz$)")
+        );
     }
 
     /**
@@ -105,7 +107,7 @@ public class TgzRelativePath {
      * @return The npm scoped path if found.
      */
     private Optional<String> curlWithoutScope() {
-        return this.firstGroup(Pattern.compile("([\\w.-]+/[\\w.-]+\\.tgz)"));
+        return this.firstGroup(Pattern.compile("([\\w.-]+/[\\w.-]+\\.tgz$)"));
     }
 
     /**

--- a/src/test/java/com/artipie/npm/RelativePathTest.java
+++ b/src/test/java/com/artipie/npm/RelativePathTest.java
@@ -74,7 +74,9 @@ public final class RelativePathTest {
     @ParameterizedTest
     @ValueSource(strings = {
         "@scope/yuanye05/yuanye05-1.0.3.tgz",
-        "@my-org/test.suffix/test.suffix-5.5.3.tgz"
+        "@my-org/test.suffix/test.suffix-5.5.3.tgz",
+        "@test-org-test/test/-/test-1.0.0.tgz",
+        "@thepeaklab/angelis/0.3.0/angelis-0.3.0.tgz"
     })
     public void curlWithScopeIdentifiedCorrectly(final String name) {
         MatcherAssert.assertThat(

--- a/src/test/java/com/artipie/npm/RelativePathTest.java
+++ b/src/test/java/com/artipie/npm/RelativePathTest.java
@@ -76,7 +76,10 @@ public final class RelativePathTest {
         "@scope/yuanye05/yuanye05-1.0.3.tgz",
         "@my-org/test.suffix/test.suffix-5.5.3.tgz",
         "@test-org-test/test/-/test-1.0.0.tgz",
-        "@thepeaklab/angelis/0.3.0/angelis-0.3.0.tgz"
+        "@thepeaklab/angelis/0.3.0/angelis-0.3.0.tgz",
+        "@aa/bb/0.3.1/@aa/bb-0.3.1.tgz",
+        "@aa/bb/0.3.1-alpha/@aa/bb-0.3.1-alpha.tgz",
+        "@aa/bb.js/0.3.1-alpha/@aa/bb.js-0.3.1-alpha.tgz"
     })
     public void curlWithScopeIdentifiedCorrectly(final String name) {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Part of #139 
Fixed a regex bug in `TgzRelativePath#curlWithScope`. Changed order in `TgzRelativePath#relative` because `npmWithoutScope` matches the part of an expression that contains `@` therefore at first it is necessary to check matching to `curlWithScope`.
Bug report: https://github.com/artipie/npm-adapter/issues/139#issuecomment-756013624