### PR TITLE
#63 - Remove todo from DownloadPackageSlice

### DIFF
--- a/src/main/java/com/artipie/npm/http/DownloadPackageSlice.java
+++ b/src/main/java/com/artipie/npm/http/DownloadPackageSlice.java
@@ -47,7 +47,6 @@ import org.reactivestreams.Publisher;
  * based on requested URL.
  *
  * @since 0.6
- * @todo #49:90m handle https schema in the <code>response</code> method
  * @checkstyle ClassDataAbstractionCouplingCheck (250 lines)
  */
 public final class DownloadPackageSlice implements Slice {


### PR DESCRIPTION
Closes #63 
Remove `todo` as it is outdated after #120 because `URL` is used as base instead of `Path`