### PR TITLE
#169 - Refactor TgzRelativePath by adding processor

### DIFF
--- a/src/main/java/com/artipie/npm/TgzRelativePath.java
+++ b/src/main/java/com/artipie/npm/TgzRelativePath.java
@@ -5,7 +5,6 @@
 package com.artipie.npm;
 
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,16 +69,6 @@ public final class TgzRelativePath {
             res = matched.firstGroup();
         }
         return res;
-    }
-
-    /**
-     * Extract the relative path and apply processor to the extracted value.
-     * @param processor Custom processor for relative path
-     * @return Processed relative path.
-     */
-    public String relative(final Function<String, String> processor) {
-        final Matched matched = this.matchedValues();
-        return processor.apply(matched.firstGroup());
     }
 
     /**

--- a/src/main/java/com/artipie/npm/TgzRelativePath.java
+++ b/src/main/java/com/artipie/npm/TgzRelativePath.java
@@ -5,6 +5,7 @@
 package com.artipie.npm;
 
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -13,7 +14,11 @@ import java.util.regex.Pattern;
  *
  * @since 0.3
  */
-final class TgzRelativePath {
+public final class TgzRelativePath {
+    /**
+     * Regex pattern for extracting version from package name.
+     */
+    private static final Pattern VRSN = Pattern.compile(".*(\\d+.\\d+.\\d+[-.\\w]*).tgz");
 
     /**
      * The full path.
@@ -24,33 +29,82 @@ final class TgzRelativePath {
      * Ctor.
      * @param full The full path.
      */
-    TgzRelativePath(final String full) {
+    public TgzRelativePath(final String full) {
         this.full = full;
     }
 
     /**
      * Extract the relative path.
      *
-     * @return The a relative path.
+     * @return The relative path.
      */
     public String relative() {
-        final Optional<String> npms = this.npmWithScope();
-        final Optional<String> npmws = this.npmWithoutScope();
-        final Optional<String> curls = this.curlWithScope();
-        final Optional<String> curlws = this.curlWithoutScope();
-        final String result;
+        return this.relative(false);
+    }
+
+    /**
+     * Extract the relative path.
+     * @param process Is it necessary to process path value by replacing
+     *  `/-/` with `/version/`. It could be required for some cases.
+     *  See <a href="https://www.jfrog.com/confluence/display/BT/npm+Repositories">
+     *  Deploying with cURL</a> section.
+     * @return The relative path.
+     */
+    public String relative(final boolean process) {
+        final Matched matched = this.matchedValues();
+        final String res;
+        if (process) {
+            final Matcher matcher = TgzRelativePath.VRSN.matcher(matched.name());
+            if (!matcher.matches()) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Failed to process path `%s` with name `%s`",
+                        matched.firstGroup(),
+                        matched.name()
+                    )
+                );
+            }
+            res = matched.firstGroup()
+                .replace("/-/", String.format("/%s/", matcher.group(1)));
+        } else {
+            res = matched.firstGroup();
+        }
+        return res;
+    }
+
+    /**
+     * Extract the relative path and apply processor to the extracted value.
+     * @param processor Custom processor for relative path
+     * @return Processed relative path.
+     */
+    public String relative(final Function<String, String> processor) {
+        final Matched matched = this.matchedValues();
+        return processor.apply(matched.firstGroup());
+    }
+
+    /**
+     * Applies different patterns depending on type of uploading and
+     * scope's presence.
+     * @return Matched values.
+     */
+    private Matched matchedValues() {
+        final Optional<Matched> npms = this.npmWithScope();
+        final Optional<Matched> npmws = this.npmWithoutScope();
+        final Optional<Matched> curls = this.curlWithScope();
+        final Optional<Matched> curlws = this.curlWithoutScope();
+        final Matched matched;
         if (npms.isPresent()) {
-            result = npms.get();
+            matched = npms.get();
         } else if (curls.isPresent()) {
-            result = curls.get();
+            matched = curls.get();
         } else if (npmws.isPresent()) {
-            result = npmws.get();
+            matched = npmws.get();
         } else if (curlws.isPresent()) {
-            result = curlws.get();
+            matched = curlws.get();
         } else {
             throw new IllegalStateException("a relative path was not found");
         }
-        return result;
+        return matched;
     }
 
     /**
@@ -58,8 +112,10 @@ final class TgzRelativePath {
      *
      * @return The npm scoped path if found.
      */
-    private Optional<String> npmWithScope() {
-        return this.firstGroup(Pattern.compile("(@[\\w-]+/[\\w.-]+/-/@[\\w-]+/[\\w.-]+.tgz$)"));
+    private Optional<Matched> npmWithScope() {
+        return this.matches(
+            Pattern.compile("(@[\\w-]+/[\\w.-]+/-/@[\\w-]+/(?<name>[\\w.-]+.tgz)$)")
+        );
     }
 
     /**
@@ -67,8 +123,10 @@ final class TgzRelativePath {
      *
      * @return The npm scoped path if found.
      */
-    private Optional<String> npmWithoutScope() {
-        return this.firstGroup(Pattern.compile("([\\w.-]+/-/[\\w.-]+.tgz$)"));
+    private Optional<Matched> npmWithoutScope() {
+        return this.matches(
+            Pattern.compile("([\\w.-]+/-/(?<name>[\\w.-]+.tgz)$)")
+        );
     }
 
     /**
@@ -76,9 +134,9 @@ final class TgzRelativePath {
      *
      * @return The npm scoped path if found.
      */
-    private Optional<String> curlWithScope() {
-        return this.firstGroup(
-            Pattern.compile("(@[\\w-]+/[\\w.-]+/(@?(?<!-/@)[\\w.-]+/)*[\\w.-]+.tgz$)")
+    private Optional<Matched> curlWithScope() {
+        return this.matches(
+            Pattern.compile("(@[\\w-]+/[\\w.-]+/(?<name>(@?(?<!-/@)[\\w.-]+/)*[\\w.-]+.tgz)$)")
         );
     }
 
@@ -87,8 +145,10 @@ final class TgzRelativePath {
      *
      * @return The npm scoped path if found.
      */
-    private Optional<String> curlWithoutScope() {
-        return this.firstGroup(Pattern.compile("([\\w.-]+/[\\w.-]+\\.tgz$)"));
+    private Optional<Matched> curlWithoutScope() {
+        return this.matches(
+            Pattern.compile("([\\w.-]+/(?<name>[\\w.-]+\\.tgz)$)")
+        );
     }
 
     /**
@@ -97,15 +157,59 @@ final class TgzRelativePath {
      * @param pattern The patter to match against.
      * @return The first group match if found.
      */
-    private Optional<String> firstGroup(final Pattern pattern) {
+    private Optional<Matched> matches(final Pattern pattern) {
         final Matcher matcher = pattern.matcher(this.full);
         final boolean found = matcher.find();
-        final Optional<String> result;
+        final Optional<Matched> result;
         if (found) {
-            result = Optional.of(matcher.group(1));
+            result = Optional.of(
+                new Matched(matcher.group(1), matcher.group("name"))
+            );
         } else {
             result = Optional.empty();
         }
         return result;
+    }
+
+    /**
+     * Contains matched values which were obtained from regex.
+     * @since 0.9
+     */
+    private static final class Matched {
+        /**
+         * First group from matcher.
+         */
+        private final String cfirstgroup;
+
+        /**
+         * Group `name` from matcher.
+         */
+        private final String cname;
+
+        /**
+         * Ctor.
+         * @param firstgroup First group from matcher
+         * @param name Group `name` from matcher
+         */
+        Matched(final String firstgroup, final String name) {
+            this.cfirstgroup = firstgroup;
+            this.cname = name;
+        }
+
+        /**
+         * Name.
+         * @return Name from matcher.
+         */
+        public String name() {
+            return this.cname;
+        }
+
+        /**
+         * First group.
+         * @return First group from matcher.
+         */
+        public String firstGroup() {
+            return this.cfirstgroup;
+        }
     }
 }

--- a/src/test/java/com/artipie/npm/RelativePathTest.java
+++ b/src/test/java/com/artipie/npm/RelativePathTest.java
@@ -6,7 +6,9 @@ package com.artipie.npm;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
+import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -82,6 +84,33 @@ public final class RelativePathTest {
                 String.format(RelativePathTest.URL, name)
             ).relative(),
             new IsEqual<>(name)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "yuanye05/-/yuanye05-1.0.3.tgz,yuanye05/1.0.3/yuanye05-1.0.3.tgz",
+        "any.suf/-/any.suf-5.5.3-alpha.tgz,any.suf/5.5.3-alpha/any.suf-5.5.3-alpha.tgz",
+        "test-some/-/test-some-5.5.3-rc1.tgz,test-some/5.5.3-rc1/test-some-5.5.3-rc1.tgz"
+    })
+    public void replacesHyphenWithVersion(final String path, final String target) {
+        MatcherAssert.assertThat(
+            new TgzRelativePath(
+                String.format(RelativePathTest.URL, path)
+            ).relative(true),
+            new IsEqual<>(target)
+        );
+    }
+
+    @Test
+    public void appliesPassedFunction() {
+        MatcherAssert.assertThat(
+            new TgzRelativePath(
+                String.format(RelativePathTest.URL, "yuanye05/-/yuanye05-1.0.3.tgz")
+            ).relative(
+                str -> str.replace("/-/", "/")
+            ),
+            new IsEqual<>("yuanye05/yuanye05-1.0.3.tgz")
         );
     }
 }

--- a/src/test/java/com/artipie/npm/RelativePathTest.java
+++ b/src/test/java/com/artipie/npm/RelativePathTest.java
@@ -6,7 +6,6 @@ package com.artipie.npm;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
-import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -99,18 +98,6 @@ public final class RelativePathTest {
                 String.format(RelativePathTest.URL, path)
             ).relative(true),
             new IsEqual<>(target)
-        );
-    }
-
-    @Test
-    public void appliesPassedFunction() {
-        MatcherAssert.assertThat(
-            new TgzRelativePath(
-                String.format(RelativePathTest.URL, "yuanye05/-/yuanye05-1.0.3.tgz")
-            ).relative(
-                str -> str.replace("/-/", "/")
-            ),
-            new IsEqual<>("yuanye05/yuanye05-1.0.3.tgz")
         );
     }
 }


### PR DESCRIPTION
Closes #169 
Added opportunity to process obtained relative path by replacing hyphen with version.
Also, made a class `public` because it was made `private` [in this PR](https://github.com/artipie/npm-adapter/commit/f8048a045767967f6bc62cbee5ad9ddf854f517c#diff-863dbc50bf7a87588099c39de9f78b06166ef4b7599959019cbd69525a0fd67b), but some of our users use `TgzRelativePath `