### PR TITLE
#169 - Fix regex bug in TgzRelativePath

### DIFF
--- a/src/main/java/com/artipie/npm/TgzRelativePath.java
+++ b/src/main/java/com/artipie/npm/TgzRelativePath.java
@@ -136,7 +136,7 @@ public final class TgzRelativePath {
      */
     private Optional<Matched> curlWithoutScope() {
         return this.matches(
-            Pattern.compile("([\\w.-]+/(?<name>[\\w.-]+\\.tgz)$)")
+            Pattern.compile("([\\w.-]+(/\\d+.\\d+.\\d+[\\w.-]*)?/(?<name>[\\w.-]+\\.tgz)$)")
         );
     }
 

--- a/src/test/java/com/artipie/npm/RelativePathTest.java
+++ b/src/test/java/com/artipie/npm/RelativePathTest.java
@@ -78,7 +78,9 @@ final class RelativePathTest {
     @ParameterizedTest
     @ValueSource(strings = {
         "yuanye05/yuanye05-1.0.3.tgz",
-        "test.suffix/test.suffix-5.5.3.tgz"
+        "yuanye05/1.0.3/yuanye05-1.0.3.tgz",
+        "test.suffix/test.suffix-5.5.3.tgz",
+        "test.suffix/5.5.3/test.suffix-5.5.3.tgz"
     })
     void curlWithoutScopeIdentifiedCorrectly(final String name) {
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #169
Fixed regex bug in `TgzRelativePath` for method `curlWithoutScope()` by adding version to path in case of existence.
Added some tests to verify it